### PR TITLE
Don't crash on missing code block languages

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,12 @@ function createProcessor () {
     .use(gemojiToEmoji)
     .use(slug)
     .use(autolinkHeadings, { behavior: 'wrap' })
-    .use(highlight)
+    .use(highlight, {
+      ignoreMissing: true,
+      aliases: {
+        'plaintext': ['text']
+      }
+    })
 }
 
 module.exports = async function markdownToHtml (markdown, options = {}) {


### PR DESCRIPTION
By default, the highlighter module throws an exception when it tries to highlight a block marked with a language that it doesn't recognize; this disables that option, and also aliases `text` to `plaintext`.