### PR TITLE
refactor: move cmark options to own category

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ electron-markdown exports a single function, which takes a Markdown string as it
 
 `resultPromise = electronMarkdown(markdown[, options])`
 
-* `result: Promise<String>` - a Promise resolving to the resulting HTML if parsing and rendering succeeds
-* `markdown: String` - a string of Markdown to render to HTML
-* `options: Object` - options to pass to [cmark-gfm](https://github.com/BinaryMuse/node-cmark-gfm#options); will be deeply merged with the default options
+- `result: Promise<String>` - a Promise resolving to the resulting HTML if parsing and rendering succeeds
+- `markdown: String` - a string of Markdown to render to HTML
+- `options: Object`
+  - `cmark` - Options to pass to [cmark-gfm](https://github.com/BinaryMuse/node-cmark-gfm#options); will be deeply merged with the default options
 
 Default options:
 
@@ -39,10 +40,12 @@ To disable an option or extension that is enabled by default, provide your own o
 ```javascript
 const markdownToHtml = require('electron-markdown')
 
-markdownToHtml(someMarkdown)
-  .then(function (html) {
-    console.log(html)
-  }, function (err) {
-    console.error(err)
-  })
+markdownToHtml(someMarkdown).then(
+  (html) => {
+    console.log(html);
+  },
+  (err) => {
+    console.error(err);
+  }
+);
 ```

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ function createProcessor () {
 }
 
 module.exports = async function markdownToHtml (markdown, options = {}) {
-  const defaultOpts = {
+  const cmarkDefaultOpts = {
     footnotes: true,
     extensions: {
       table: true,
@@ -31,7 +31,7 @@ module.exports = async function markdownToHtml (markdown, options = {}) {
     }
   }
 
-  const html = await cmark.renderHtml(markdown, mixin(defaultOpts, options))
+  const html = await cmark.renderHtml(markdown, mixin(cmarkDefaultOpts, options.cmark))
   const { contents } = await createProcessor().process(html)
   return contents
 }

--- a/test/index.js
+++ b/test/index.js
@@ -51,18 +51,18 @@ describe('markdownToHtml', () => {
     expect($('pre code.hljs').length).to.eql(1)
   })
 
-  describe('options', () => {
+  describe('options.cmark', () => {
     it('allows additional cmark options', async () => {
       content = await markdownToHtml(fixtures.unsafe)
       expect(content).not.to.include('img')
-      content = await markdownToHtml(fixtures.unsafe, { unsafe: true })
+      content = await markdownToHtml(fixtures.unsafe, { cmark: { unsafe: true } })
       expect(content).to.include('img')
     })
 
     it('allows removing extensions', async () => {
       content = await markdownToHtml(fixtures.table)
       expect(content).to.include('table')
-      content = await markdownToHtml(fixtures.table, { extensions: { table: false } })
+      content = await markdownToHtml(fixtures.table, { cmark: { extensions: { table: false } }})
       expect(content).not.to.include('table')
     })
 
@@ -70,7 +70,7 @@ describe('markdownToHtml', () => {
       content = await markdownToHtml(fixtures.tasklist)
       expect(content).not.to.include('checkbox')
       expect(content).to.include('href')
-      content = await markdownToHtml(fixtures.tasklist, { extensions: { tasklist: true, autolink: false } })
+      content = await markdownToHtml(fixtures.tasklist, { cmark:  { extensions: { tasklist: true, autolink: false } }})
       expect(content).to.include('checkbox')
       expect(content).not.to.include('href')
     })


### PR DESCRIPTION
Previously all options are `cmark` options, now she has own category.

Previously:

```javascript
const html = markdownToHtml('text', { unsafe: true })
```

New:

```javascript
const html = markdownToHtml('text', { cmark: { unsafe: true } })
```